### PR TITLE
Updated Line 112 in acf-ninja-forms-field-v5.php

### DIFF
--- a/acf-ninja-forms-field-v5.php
+++ b/acf-ninja-forms-field-v5.php
@@ -109,7 +109,7 @@ class acf_field_ninja_forms extends acf_field {
 
     if ( $forms ) {
       foreach( $forms as $form ) {
-        $choices[ $form[ 'id' ] ] = ucfirst( $form[ 'data' ][ 'form_title' ] );
+        $choices[ $form[ 'id' ] ] = ucfirst( $form[ 'data' ][ 'title' ] );
       }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI: http://opensource.org/licenses/MIT
 Tags: ninja forms, acf, advanced custom fields, forms
 Requires at least: 3.8
 Tested up to: 4.2
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 
 Adds an Advanced Custom Fields field to select one or many Ninja Forms.
 
@@ -58,6 +58,10 @@ Thanks to Adam Pope for the [ACF Gravity Forms](https://github.com/stormuk/Gravi
 1. Activate the Advanced Custom Fields: Ninja Forms Field plugin through the 'Plugins' menu in WordPress
 
 == Changelog ==
+
+= 1.0.3 =
+
+* Updated field name on line 112 for v5 to title instead of form_title
 
 = 1.0.2 =
 


### PR DESCRIPTION
Old field was `form_title` while the latest version of Ninja Forms uses `title` now.