### PR TITLE
Looks like a placeholder was left here

### DIFF
--- a/acf-ninja-forms-field-v4.php
+++ b/acf-ninja-forms-field-v4.php
@@ -262,4 +262,4 @@ class acf_field_ninja_forms extends acf_field {
 }
 
 // create field
-new acf_field_FIELD_NAME();
+new acf_field_ninja_forms();


### PR DESCRIPTION
Plugin error before this change:
( ! ) Fatal error: Uncaught Error: Class 'acf_field_FIELD_NAME' not found in ..../wp-content/plugins/acf-ninja-forms/acf-ninja-forms-field-v4.php on line 265

post-fix working correctly on ACF V 4.4.12, NinjaForms V3.2.4

P.S Tried numerous other methods with no success. After this fix your plugin is working pefectly